### PR TITLE
Add amqp admin

### DIFF
--- a/src/main/java/uk/gov/ons/fwmt/fwmtrmadapter/config/FWMTQueueConfig.java
+++ b/src/main/java/uk/gov/ons/fwmt/fwmtrmadapter/config/FWMTQueueConfig.java
@@ -1,12 +1,14 @@
 package uk.gov.ons.fwmt.fwmtrmadapter.config;
 
 import org.aopalliance.aop.Advice;
+import org.springframework.amqp.core.AmqpAdmin;
 import org.springframework.amqp.core.Binding;
 import org.springframework.amqp.core.BindingBuilder;
 import org.springframework.amqp.core.DirectExchange;
 import org.springframework.amqp.core.Queue;
 import org.springframework.amqp.core.QueueBuilder;
 import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitAdmin;
 import org.springframework.amqp.rabbit.listener.SimpleMessageListenerContainer;
 import org.springframework.amqp.rabbit.listener.adapter.MessageListenerAdapter;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -47,76 +49,98 @@ public class FWMTQueueConfig {
   // Queue
   @Bean
   public Queue adapterToJobSvcQueue() {
-    return QueueBuilder.durable(QueueNames.ADAPTER_TO_JOBSVC_QUEUE)
+    Queue queue = QueueBuilder.durable(QueueNames.ADAPTER_TO_JOBSVC_QUEUE)
         .withArgument("x-dead-letter-exchange", "")
         .withArgument("x-dead-letter-routing-key", QueueNames.ADAPTER_JOB_SVC_DLQ)
         .build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   @Bean
   public Queue jobSvcToAdapterQueue() {
-    return QueueBuilder.durable(QueueNames.JOBSVC_TO_ADAPTER_QUEUE)
+    Queue queue = QueueBuilder.durable(QueueNames.JOBSVC_TO_ADAPTER_QUEUE)
         .withArgument("x-dead-letter-exchange", "")
         .withArgument("x-dead-letter-routing-key", QueueNames.JOB_SVC_ADAPTER_DLQ)
         .build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   @Bean
   public Queue adapterToRmQueue() {
-    return QueueBuilder.durable(QueueNames.ADAPTER_TO_RM_QUEUE)
+    Queue queue = QueueBuilder.durable(QueueNames.ADAPTER_TO_RM_QUEUE)
         .withArgument("x-dead-letter-exchange", "")
         .withArgument("x-dead-letter-routing-key", QueueNames.ADAPTER_RM_DLQ)
         .build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   // Dead Letter Queues
   @Bean
   public Queue adapterDeadLetterQueue() {
-    return QueueBuilder.durable(QueueNames.ADAPTER_JOB_SVC_DLQ).build();
+    Queue queue = QueueBuilder.durable(QueueNames.ADAPTER_JOB_SVC_DLQ).build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   @Bean
   public Queue jobSvsDeadLetterQueue() {
-    return QueueBuilder.durable(QueueNames.JOB_SVC_ADAPTER_DLQ).build();
+    Queue queue = QueueBuilder.durable(QueueNames.JOB_SVC_ADAPTER_DLQ).build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   @Bean
   public Queue rmAdapterDeadLetterQueue() {
-    return QueueBuilder.durable(QueueNames.RM_ADAPTER_DLQ).build();
+    Queue queue = QueueBuilder.durable(QueueNames.RM_ADAPTER_DLQ).build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   @Bean
   public Queue adapterRmDeadLetterQueue() {
-    return QueueBuilder.durable(QueueNames.ADAPTER_RM_DLQ).build();
+    Queue queue = QueueBuilder.durable(QueueNames.ADAPTER_RM_DLQ).build();
+    queue.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return queue;
   }
 
   // Exchange
   @Bean
   @Primary
   public DirectExchange fwmtExchange() {
-    return new DirectExchange(QueueNames.RM_JOB_SVC_EXCHANGE);
+    DirectExchange directExchange = new DirectExchange(QueueNames.RM_JOB_SVC_EXCHANGE);
+    directExchange.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return directExchange;
   }
 
   // Bindings
   @Bean
   public Binding adapterToJobSvcBinding(@Qualifier("adapterToJobSvcQueue") Queue queue,
       @Qualifier("fwmtExchange") DirectExchange directExchange) {
-    return BindingBuilder.bind(queue).to(directExchange)
+    Binding binding = BindingBuilder.bind(queue).to(directExchange)
         .with(QueueNames.JOB_SVC_REQUEST_ROUTING_KEY);
+    binding.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return binding;
   }
 
   @Bean
   public Binding jobSvcToAdapterBinding(@Qualifier("jobSvcToAdapterQueue") Queue queue,
       @Qualifier("fwmtExchange") DirectExchange directExchange) {
-    return BindingBuilder.bind(queue).to(directExchange)
+    Binding binding = BindingBuilder.bind(queue).to(directExchange)
         .with(QueueNames.JOB_SVC_RESPONSE_ROUTING_KEY);
+    binding.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return binding;
   }
 
   @Bean
   public Binding adapterToRmBinding(@Qualifier("adapterToRmQueue") Queue queue,
       @Qualifier("fwmtExchange") DirectExchange directExchange) {
-    return BindingBuilder.bind(queue).to(directExchange)
+    Binding binding = BindingBuilder.bind(queue).to(directExchange)
         .with(QueueNames.RM_RESPONSE_ROUTING_KEY);
+    binding.setAdminsThatShouldDeclare(fwmtAmqpAdmin());
+    return binding;
   }
 
   // Listener
@@ -150,6 +174,11 @@ public class FWMTQueueConfig {
     container.setQueueNames(QueueNames.JOBSVC_TO_ADAPTER_QUEUE);
     container.setMessageListener(messageListenerAdapter);
     return container;
+  }
+
+  @Bean
+  public AmqpAdmin fwmtAmqpAdmin() {
+    return new RabbitAdmin(fwmtConnectionFactory());
   }
 
   // Connection Factory

--- a/src/main/java/uk/gov/ons/fwmt/fwmtrmadapter/config/RMQueueConfig.java
+++ b/src/main/java/uk/gov/ons/fwmt/fwmtrmadapter/config/RMQueueConfig.java
@@ -68,11 +68,11 @@ public class RMQueueConfig {
   }
 
   // Bindings
+
   @Bean
-  public Binding rmToAdapterBinding(@Qualifier("rmToAdapterQueue") Queue queue,
-      @Qualifier("rmExchange") DirectExchange directExchange) {
-    Binding binding = BindingBuilder.bind(queue).to(directExchange)
-        .with(ACTION_FIELD_BINDING);
+  public Binding rmToAdapterBinding() {
+    Binding binding = BindingBuilder.bind(adapterDeadLetterQueue()).to(actionDlqExchange())
+        .with("Action.Field.binding");
     binding.setAdminsThatShouldDeclare(rmAmqpAdmin());
     return binding;
   }
@@ -84,9 +84,10 @@ public class RMQueueConfig {
   }
 
   // Exchange
+
   @Bean
-  public DirectExchange rmExchange() {
-    DirectExchange exchange = new DirectExchange(ACTION_FIELD_BINDING);
+  public DirectExchange actionDlqExchange() {
+    DirectExchange exchange = new DirectExchange("action-deadletter-exchange");
     exchange.setAdminsThatShouldDeclare(rmAmqpAdmin());
     return exchange;
   }

--- a/src/main/java/uk/gov/ons/fwmt/fwmtrmadapter/config/RMQueueConfig.java
+++ b/src/main/java/uk/gov/ons/fwmt/fwmtrmadapter/config/RMQueueConfig.java
@@ -28,6 +28,7 @@ public class RMQueueConfig {
   private static final String ACTION_FIELD_DLQ = "Action.FieldDLQ";
   private static final String ACTION_FIELD_QUEUE = "Action.Field";
   private static final String ACTION_FIELD_BINDING = "Action.Field.binding";
+  public static final String ACTION_DEADLETTER_EXCHANGE = "action-deadletter-exchange";
 
   private String username;
   private String password;
@@ -52,8 +53,8 @@ public class RMQueueConfig {
   @Bean
   public Queue rmToAdapterQueue() {
     Queue queue = QueueBuilder.durable(ACTION_FIELD_QUEUE)
-        .withArgument("x-dead-letter-exchange", "action-deadletter-exchange")
-        .withArgument("x-dead-letter-routing-key", "Action.Field.binding")
+        .withArgument("x-dead-letter-exchange", ACTION_DEADLETTER_EXCHANGE)
+        .withArgument("x-dead-letter-routing-key", ACTION_FIELD_BINDING)
         .build();
     queue.setAdminsThatShouldDeclare(rmAmqpAdmin());
     return queue;
@@ -72,7 +73,7 @@ public class RMQueueConfig {
   @Bean
   public Binding rmToAdapterBinding() {
     Binding binding = BindingBuilder.bind(adapterDeadLetterQueue()).to(actionDlqExchange())
-        .with("Action.Field.binding");
+        .with(ACTION_FIELD_BINDING);
     binding.setAdminsThatShouldDeclare(rmAmqpAdmin());
     return binding;
   }
@@ -87,7 +88,7 @@ public class RMQueueConfig {
 
   @Bean
   public DirectExchange actionDlqExchange() {
-    DirectExchange exchange = new DirectExchange("action-deadletter-exchange");
+    DirectExchange exchange = new DirectExchange(ACTION_DEADLETTER_EXCHANGE);
     exchange.setAdminsThatShouldDeclare(rmAmqpAdmin());
     return exchange;
   }


### PR DESCRIPTION
add amqp admin to specify which rabbitmq instance to create queues and exchanges on, this is needed as without this everything is created on both instances